### PR TITLE
Improve web UI validation, P2P flow, and sharing-code resolution

### DIFF
--- a/server/public/css/index.css
+++ b/server/public/css/index.css
@@ -30,6 +30,36 @@
   justify-content: center;
 }
 
+#statusAlert {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1080;
+  width: min(720px, calc(100% - 2rem));
+  margin: 0;
+}
+
+.btn-group .btn-outline-primary:not(.active):not(:disabled):hover,
+.btn-group .btn-outline-primary:not(.active):not(.disabled):hover {
+  background-color: rgba(var(--bs-primary-rgb), 0.12);
+  border-color: rgba(var(--bs-primary-rgb), 0.35);
+  color: var(--bs-primary);
+}
+
+.btn-group .btn-outline-primary:not(.active):not(:disabled):active,
+.btn-group .btn-outline-primary:not(.active):not(.disabled):active {
+  background-color: rgba(var(--bs-primary-rgb), 0.2);
+  border-color: rgba(var(--bs-primary-rgb), 0.45);
+  color: var(--bs-primary);
+}
+
+.btn-group .btn:disabled,
+.btn-group .btn.disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .code-box {
   display: inline-block;
   padding: .65rem 1rem;

--- a/server/public/js/download-p2p.js
+++ b/server/public/js/download-p2p.js
@@ -1,173 +1,121 @@
-(() => {
-  const elTitle = document.getElementById('title');
-  const elMsg = document.getElementById('message');
-  const elMeta = document.getElementById('meta');
-  const elBar = document.getElementById('bar');
-  const elBytes = document.getElementById('bytes');
-  const elActions = document.getElementById('actions');
-  const retryBtn = document.getElementById('retryBtn');
+import { ShadownloaderClient, isSecureContextForP2P, startP2PReceive } from './shadownloader-core.js';
 
-  retryBtn?.addEventListener('click', () => location.reload());
+const elTitle = document.getElementById('title');
+const elMsg = document.getElementById('message');
+const elMeta = document.getElementById('meta');
+const elBar = document.getElementById('bar');
+const elBytes = document.getElementById('bytes');
+const elActions = document.getElementById('actions');
+const retryBtn = document.getElementById('retryBtn');
 
-  const code = document.body.dataset.code;
+retryBtn?.addEventListener('click', () => location.reload());
 
-  let writer = null;
-  let total = 0;
-  let received = 0;
+const code = document.body.dataset.code;
 
-  const fmtBytes = (bytes) => {
-    if (!Number.isFinite(bytes)) return '0 B';
-    const units = ['B','KB','MB','GB','TB'];
-    let v = bytes;
-    let u = 0;
-    while (v >= 1024 && u < units.length - 1) { v /= 1024; u++; }
-    const dp = v < 10 && u > 0 ? 2 : (v < 100 ? 1 : 0);
-    return `${v.toFixed(dp)} ${units[u]}`;
-  };
+let total = 0;
+let received = 0;
 
-  const setProgress = () => {
-    const pct = total > 0 ? Math.min(100, (received / total) * 100) : 0;
-    elBar.style.width = `${pct}%`;
-    elBytes.textContent = `${fmtBytes(received)} / ${fmtBytes(total)}`;
-  };
+const fmtBytes = (bytes) => {
+  if (!Number.isFinite(bytes)) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let v = bytes;
+  let u = 0;
+  while (v >= 1024 && u < units.length - 1) { v /= 1024; u++; }
+  const dp = v < 10 && u > 0 ? 2 : (v < 100 ? 1 : 0);
+  return `${v.toFixed(dp)} ${units[u]}`;
+};
 
-  const showError = (title, message) => {
-    elTitle.textContent = title;
-    elMsg.textContent = message;
-    elMeta.hidden = true;
-    elActions.hidden = false;
-  };
+const setProgress = () => {
+  const pct = total > 0 ? Math.min(100, (received / total) * 100) : 0;
+  elBar.style.width = `${pct}%`;
+  elBytes.textContent = `${fmtBytes(received)} / ${fmtBytes(total)}`;
+};
 
-  async function getInfo() {
-    const res = await fetch('/api/info', { cache: 'no-store' });
-    if (!res.ok) throw new Error('Failed to fetch server info');
-    return res.json();
+const showError = (title, message) => {
+  elTitle.textContent = title;
+  elMsg.textContent = message;
+  elMeta.hidden = true;
+  elActions.hidden = false;
+};
+
+async function loadServerInfo() {
+  const client = new ShadownloaderClient({ clientVersion: '0.0.0' });
+  const { serverInfo } = await client.getServerInfo(location.origin, { timeoutMs: 5000 });
+  return serverInfo;
+}
+
+async function start() {
+  if (!code) {
+    showError('Invalid link', 'No sharing code was provided.');
+    return;
   }
 
-  async function start() {
-    if (!code) {
-      showError('Invalid link', 'No sharing code was provided.');
-      return;
-    }
+  if (!isSecureContextForP2P()) {
+    showError('Secure connection required', 'P2P transfers require HTTPS in most browsers.');
+    return;
+  }
 
-    if (!window.isSecureContext && location.hostname !== 'localhost') {
-      showError('Secure connection required', 'P2P transfers require HTTPS in most browsers.');
-      return;
-    }
+  elTitle.textContent = 'Connecting…';
+  elMsg.textContent = `Connecting to ${code}…`;
 
-    if (typeof window.Peer !== 'function') {
-      showError('PeerJS not loaded', 'The PeerJS client library is missing. Make sure peerjs is installed on the server.');
-      return;
-    }
+  let info;
+  try {
+    info = await loadServerInfo();
+  } catch {
+    info = {};
+  }
 
-    elTitle.textContent = 'Connecting…';
-    elMsg.textContent = `Connecting to ${code}…`;
+  const p2p = info?.capabilities?.p2p || {};
+  if (p2p.enabled === false) {
+    showError('Direct transfer disabled', 'This server has P2P disabled.');
+    return;
+  }
 
-    let info;
-    try {
-      info = await getInfo();
-    } catch {
-      // still try to connect with defaults
-      info = {};
-    }
+  const peerjsPath = p2p.peerjsPath || '/peerjs';
+  const iceServers = Array.isArray(p2p.iceServers) ? p2p.iceServers : [];
 
-    const p2p = info?.capabilities?.p2p || {};
-    if (p2p.enabled === false) {
-      showError('Direct transfer disabled', 'This server has P2P disabled.');
-      return;
-    }
-
-    const peerPath = p2p.peerjsPath || '/peerjs';
-    const iceServers = Array.isArray(p2p.iceServers) ? p2p.iceServers : [];
-
-    const secure = location.protocol === 'https:' || location.hostname === 'localhost';
-    /** @type {any} */
-    const peerOpts = {
-      host: location.hostname,
-      path: peerPath,
-      secure,
-      config: { iceServers },
-    };
-
-    if (location.port) peerOpts.port = Number(location.port);
-
-    const peer = new window.Peer(undefined, peerOpts);
-
-    peer.on('error', (err) => {
-      console.error(err);
-      showError('Connection failed', err?.message || 'Could not connect.');
-    });
-
-    peer.on('open', () => {
-      const conn = peer.connect(code, { reliable: true });
-
-      conn.on('open', () => {
+  try {
+    await startP2PReceive({
+      code,
+      peerjsPath,
+      iceServers,
+      onStatus: () => {
         elTitle.textContent = 'Connected';
         elMsg.textContent = 'Waiting for file details…';
-        try { conn.send({ t: 'ready' }); } catch {}
-      });
-
-      conn.on('data', async (data) => {
-        try {
-          if (data && typeof data === 'object' && !(data instanceof ArrayBuffer) && !ArrayBuffer.isView(data) && data.t) {
-            if (data.t === 'meta') {
-              const name = String(data.name || 'file');
-              total = Number(data.size) || 0;
-              received = 0;
-              elMeta.hidden = false;
-              elMeta.textContent = `Receiving: ${name} (${fmtBytes(total)})`;
-              elTitle.textContent = 'Receiving…';
-              elMsg.textContent = 'Keep this tab open until the transfer completes.';
-
-              const stream = streamSaver.createWriteStream(name, total ? { size: total } : undefined);
-              writer = stream.getWriter();
-              setProgress();
-              return;
-            }
-
-            if (data.t === 'end') {
-              if (writer) await writer.close();
-              elTitle.textContent = 'Complete';
-              elMsg.textContent = 'Transfer finished.';
-              elMeta.textContent = 'Saved to your downloads.';
-              elActions.hidden = false;
-              return;
-            }
-
-            if (data.t === 'error') {
-              throw new Error(data.message || 'Sender reported an error.');
-            }
-            return;
-          }
-
-          // binary chunk
-          if (!writer) return;
-
-          let buf;
-          if (data instanceof ArrayBuffer) buf = new Uint8Array(data);
-          else if (ArrayBuffer.isView(data)) buf = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
-          else return;
-
-          await writer.write(buf);
-          received += buf.byteLength;
-          setProgress();
-        } catch (err) {
-          console.error(err);
-          showError('Transfer error', err?.message || 'An error occurred during the transfer.');
-          try { writer?.abort(); } catch {}
-          try { conn.close(); } catch {}
-          try { peer.destroy(); } catch {}
-        }
-      });
-
-      conn.on('close', () => {
-        if (received > 0 && total > 0 && received < total) {
-          showError('Disconnected', 'The sender disconnected before the transfer finished.');
-        }
-      });
+      },
+      onMeta: ({ name, total: nextTotal }) => {
+        total = nextTotal;
+        received = 0;
+        elMeta.hidden = false;
+        elMeta.textContent = `Receiving: ${name} (${fmtBytes(total)})`;
+        elTitle.textContent = 'Receiving…';
+        elMsg.textContent = 'Keep this tab open until the transfer completes.';
+        setProgress();
+      },
+      onProgress: ({ received: nextReceived, total: nextTotal }) => {
+        received = nextReceived;
+        total = nextTotal;
+        setProgress();
+      },
+      onComplete: () => {
+        elTitle.textContent = 'Complete';
+        elMsg.textContent = 'Transfer finished.';
+        elMeta.textContent = 'Saved to your downloads.';
+        elActions.hidden = false;
+      },
+      onError: (err) => {
+        console.error(err);
+        showError('Transfer error', err?.message || 'An error occurred during the transfer.');
+      },
+      onDisconnect: () => {
+        showError('Disconnected', 'The sender disconnected before the transfer finished.');
+      },
     });
+  } catch (err) {
+    console.error(err);
+    showError('Connection failed', err?.message || 'Could not connect.');
   }
+}
 
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start);
-  else start();
-})();
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', () => void start());
+else void start();

--- a/server/public/js/page-common.js
+++ b/server/public/js/page-common.js
@@ -1,9 +1,10 @@
+import { ShadownloaderClient } from './shadownloader-core.js';
+
 (async () => {
   try {
-    const res = await fetch('/api/info', { cache: 'no-store' });
-    if (!res.ok) return;
-    const data = await res.json();
-    const v = data?.version ? `v${data.version}` : '';
+    const client = new ShadownloaderClient({ clientVersion: '0.0.0' });
+    const { serverInfo } = await client.getServerInfo(location.origin, { timeoutMs: 5000 });
+    const v = serverInfo?.version ? `v${serverInfo.version}` : '';
 
     const el1 = document.getElementById('serverVersion');
     if (el1) el1.textContent = v;

--- a/server/views/pages/404.ejs
+++ b/server/views/pages/404.ejs
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="/css/error.css" />
 
   <script src="/js/theme.js" defer></script>
-  <script src="/js/page-common.js" defer></script>
+  <script type="module" src="/js/page-common.js"></script>
 </head>
 
 <body>

--- a/server/views/pages/download-p2p.ejs
+++ b/server/views/pages/download-p2p.ejs
@@ -21,9 +21,8 @@
 
   <script src="/assets/streamsaver.min.js"></script>
   <script src="/js/theme.js" defer></script>
-  <script src="/js/page-common.js" defer></script>
-  <script src="/vendor/peerjs.min.js" defer></script>
-  <script src="/js/download-p2p.js" defer></script>
+  <script type="module" src="/js/page-common.js"></script>
+  <script type="module" src="/js/download-p2p.js"></script>
 </head>
 
 <body data-code="<%= code %>">

--- a/server/views/pages/download-standard.ejs
+++ b/server/views/pages/download-standard.ejs
@@ -21,7 +21,7 @@
 
   <script src="/assets/streamsaver.min.js"></script>
   <script src="/js/theme.js" defer></script>
-  <script src="/js/page-common.js" defer></script>
+  <script type="module" src="/js/page-common.js"></script>
   <script src="/js/download-standard.js" defer></script>
 </head>
 

--- a/server/views/pages/index.ejs
+++ b/server/views/pages/index.ejs
@@ -24,7 +24,7 @@
 
   <script src="/js/theme.js" defer></script>
   <script src="/js/tooltips.js" defer></script>
-  <script src="/js/page-common.js" defer></script>
+  <script type="module" src="/js/page-common.js"></script>
   <script type="module" src="/js/webui-main.js"></script>
 </head>
 
@@ -92,10 +92,12 @@
               <div id="optLifetime" class="mb-3">
                 <div class="form-label fw-semibold mb-1">File Lifetime</div>
                 <div class="input-group">
-                  <input id="lifetimeValue" class="form-control" type="number" min="0" step="1" value="2" />
+                  <input id="lifetimeValue" class="form-control" type="number" min="0" step="0.5" value="24" />
                   <select id="lifetimeUnit" class="form-select" aria-label="Lifetime unit" style="max-width: 9rem;">
-                    <option value="hours">Hours</option>
-                    <option value="days" selected>Days</option>
+                    <option value="minutes">Minutes</option>
+                    <option value="hours" selected>Hours</option>
+                    <option value="days">Days</option>
+                    <option value="unlimited">Unlimited</option>
                   </select>
                 </div>
                 <div class="form-text" id="lifetimeHelp">Loading…</div>

--- a/server/views/pages/insecure.ejs
+++ b/server/views/pages/insecure.ejs
@@ -20,7 +20,7 @@
   <link rel="stylesheet" href="/css/error.css" />
 
   <script src="/js/theme.js" defer></script>
-  <script src="/js/page-common.js" defer></script>
+  <script type="module" src="/js/page-common.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
### Motivation
- Provide a single, shareable ES module for all communication and P2P logic so clients (web/Electron) use the same interface and behavior.
- Make the web UI surface clearer errors and fallbacks for Direct Transfer (P2P) and Standard uploads (size/lifetime/encryption), and avoid silent failures when files are too large or secure context requirements are not met.
- Validate sharing codes/URLs before redirecting the user so the UI can show helpful messages instead of blindly navigating.

### Description
- Centralised P2P and network utilities into `server/public/js/shadownloader-core.js` including `isSecureContextForP2P`, `startP2PSend`, `startP2PReceive`, `ensurePeerJsLoaded`, `generateP2PCode`, and `resolveShareTarget` for share-code resolution and P2P flows, plus helpers like `estimateTotalUploadSizeBytes` and `lifetimeToMs`.
- Reworked the Web UI to import and use core utilities from `shadownloader-core.js`, updated `server/public/js/webui-main.js` to validate file size against server limits (and auto-switch to P2P if available), to validate lifetime against server limits, and to disable/grey out unavailable controls using `setDisabled`.
- Replaced / modernised client scripts and pages to module-based loads: `server/public/js/download-p2p.js` now uses core receive logic, `server/public/js/page-common.js` and relevant view templates now import modules via `type="module"`.
- Added a server endpoint `POST /api/resolve` and client wrapper `ShadownloaderClient.resolveShareTarget()` to validate / normalise pasted sharing codes/URLs and return canonical targets before redirecting.
- UX/CSS tweaks: fixed-position toasts (`#statusAlert`) that don’t push page content, hover/active styling for outline buttons, disabled button visual state, `File Lifetime` UI additions (minutes/unlimited, step change), and lifetime input behaviour to match the Electron client.
- Improved compatibility and error messaging: server logs now warn about browser security requirements for P2P, `shadownloader-core` throws clearer validation errors when Web Crypto is unavailable, and upload progress callbacks use `onProgress` consistently.

### Testing
- Attempted to start the server with `node server.js` to exercise server APIs and pages, but startup failed due to missing runtime dependencies (`Error: Cannot find module 'express'`), so end-to-end server testing could not be completed in this environment.
- Static checks performed: code was linted by inspection while integrating modules and the codebase committed successfully (no automated test suite executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d8a7799c08322a51eedfb5a1cae2c)