### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   publish_image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/WillTDA/Dropgate/security/code-scanning/1](https://github.com/WillTDA/Dropgate/security/code-scanning/1)

In general, you fix this by adding an explicit `permissions` block either at the top level of the workflow (applied to all jobs) or inside the specific job, granting only what the workflow needs. For most build-and-publish workflows that only read the repository contents and push to an external registry with separate credentials, `contents: read` is typically sufficient.

For this particular workflow, it only needs to read the repository (for `actions/checkout` and `jq` reading `server/package.json`) and then interact with Docker Hub via its own secrets. It does not create or modify GitHub issues, PRs, releases, or packages. The safest minimal change is to add a job-level `permissions` block under `publish_image:` with `contents: read`. This constrains `GITHUB_TOKEN` for this job without altering any functionality.

Concretely:
- Edit `.github/workflows/docker-image.yml`.
- Under `jobs: publish_image:`, add:

```yml
    permissions:
      contents: read
```

indented to align with `runs-on`. No additional imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
