### PR TITLE
Proofread and tidy monorepo READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ Dropgate was built to make **secure file sharing accessible**, **transparent**, 
 
 ```
 /Dropgate
-├── client/    # Electron-based uploader app (GPL-3.0)
-├── server/    # Node.js server + Web UI (AGPL-3.0)
+├── client/                  # Electron-based uploader app (GPL-3.0)
+├── server/                  # Node.js server + Web UI (AGPL-3.0)
 ├── packages/
-│   ├── dropgate-core/      # Shared TypeScript library (Apache-2.0)
-├── docs/      # Privacy, troubleshooting, and technical notes
+│   └── dropgate-core/       # Shared TypeScript library (Apache-2.0)
+└── docs/                    # Privacy, troubleshooting, and technical notes
 ```
 
 
@@ -142,7 +142,7 @@ If you self-host, you decide how strict you want to be — from private-only to 
 This project uses AI tools to aid development.
 
 AI is used to:
-- Plan sigificant changes
+- Plan significant changes
 - Implement initial passes of new features
 - Perform security audits (alongside human review)
 - Fix bugs and patch security vulnerabilities

--- a/client/README.md
+++ b/client/README.md
@@ -12,8 +12,8 @@
 ![version](https://img.shields.io/badge/version-3.0.13-brightgreen?style=flat-square)
 ![platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square)
 
-[![discord](https://img.shields.io/discord/667479986214666272?logo=discord\&logoColor=white\&style=flat-square)](https://diamonddigital.dev/discord)
-[![buy me a coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee\&logoColor=000000\&style=flat-square)](https://www.buymeacoffee.com/willtda)
+[![discord](https://img.shields.io/discord/667479986214666272?logo=discord&logoColor=white&style=flat-square)](https://diamonddigital.dev/discord)
+[![buy me a coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000&style=flat-square)](https://www.buymeacoffee.com/willtda)
 
 </div>
 
@@ -129,7 +129,7 @@ See the [LICENSE](./LICENSE) file for details.
 This project uses AI tools to aid development.
 
 AI is used to:
-- Plan sigificant changes
+- Plan significant changes
 - Implement initial passes of new features
 - Perform security audits (alongside human review)
 - Fix bugs and patch security vulnerabilities

--- a/packages/dropgate-core/README.md
+++ b/packages/dropgate-core/README.md
@@ -17,9 +17,9 @@
 
 </div>
 
-## Overview
+## 🌍 Overview
 
-**@dropgate/core** is the universal client library for Dropgate. It provides all the core functionality for:
+**@dropgate/core** is the universal client library for Dropgate. It implements the client side of the Dropgate protocols — [DGUP (Dropgate Upload Protocol)](../../docs/technical/DGUP.md) for hosted uploads and [DGDTP (Dropgate Direct Transfer Protocol)](../../docs/technical/DGDTP.md) for peer-to-peer transfers — and provides all the core functionality for:
 
 - Uploading files to Dropgate servers (with optional E2EE)
 - Downloading files from Dropgate servers
@@ -29,13 +29,13 @@
 
 This package is **headless** and **environment-agnostic** — it contains no DOM manipulation, no browser-specific APIs, and no Node.js-specific code. All environment-specific concerns (loading PeerJS, handling file streams, etc.) are handled by the consumer.
 
-## Installation
+## 📦 Installation
 
 ```bash
 npm install @dropgate/core
 ```
 
-## Builds
+## 🏗️ Builds
 
 The package ships with multiple build targets:
 
@@ -45,7 +45,7 @@ The package ships with multiple build targets:
 | CJS | `dist/index.cjs` | Legacy Node.js, CommonJS |
 | Browser IIFE | `dist/index.browser.js` | `<script>` tag, exposes `DropgateCore` global |
 
-## Quick Start
+## 🚀 Quick Start
 
 ### Configure Once, Use Everywhere
 
@@ -243,7 +243,7 @@ const { serverInfo } = await getServerInfo({
 console.log('Server version:', serverInfo.version);
 ```
 
-## Metadata Fetching
+## 🧾 Metadata Fetching
 
 The core library provides intelligent metadata fetching methods that handle all the complexity of deriving computed fields from server responses.
 
@@ -278,7 +278,7 @@ const meta = await client.getBundleMetadata('bundle-id', 'optional-key');
 // meta.totalSizeBytes and meta.fileCount are computed client-side
 ```
 
-## API Reference
+## 📚 API Reference
 
 ### DropgateClient
 
@@ -414,7 +414,7 @@ zipWriter.finalize(); // Flush remaining data and write ZIP footer
 | `DropgateAbortError` | Operation aborted |
 | `DropgateTimeoutError` | Operation timed out |
 
-## Browser Usage
+## 🌐 Browser Usage
 
 For browser environments, you can use the IIFE bundle:
 
@@ -437,7 +437,7 @@ Or as an ES module:
 </script>
 ```
 
-## P2P Consumer Responsibilities
+## 🧩 P2P Consumer Responsibilities
 
 The P2P methods are **headless**. The consumer is responsible for:
 
@@ -457,12 +457,12 @@ The P2P implementation is designed for **unlimited file sizes** with constant me
 
 > **Note**: For large files, always use the `onData` callback approach rather than buffering in memory.
 
-## License
+## 📜 License
 
 Licensed under the **Apache-2.0 License**.
 See the [LICENSE](./LICENSE) file for details.
 
-## Acknowledgements
+## 📖 Acknowledgements
 
 * Logo designed by [TheFuturisticIdiot](https://github.com/TheFuturisticIdiot)
 * Built with [TypeScript](https://www.typescriptlang.org/)
@@ -473,7 +473,7 @@ See the [LICENSE](./LICENSE) file for details.
 This project uses AI tools to aid development.
 
 AI is used to:
-- Plan sigificant changes
+- Plan significant changes
 - Implement initial passes of new features
 - Perform security audits (alongside human review)
 - Fix bugs and patch security vulnerabilities
@@ -490,11 +490,11 @@ AI has a tendency to hallucinate/produce plausible but suboptimal, inaccurate or
 
 Every commit is manually reviewed and approved by a member of Diamond Digital Development, and testing is carried out to ensure changes work as intended, do not introduce regressions, and meet reliability and security expectations before being merged into the `master` branch.
 
-## Contact Us
+## 🙂 Contact Us
 
-* **Need help or want to chat?** [Join our Discord Server](https://diamonddigital.dev/discord)
-* **Found a bug?** [Open an issue](https://github.com/diamonddigitaldev/Dropgate/issues)
-* **Have a suggestion?** [Submit a feature request](https://github.com/diamonddigitaldev/Dropgate/issues/new?labels=enhancement)
+* 💬 **Need help or want to chat?** [Join our Discord Server](https://diamonddigital.dev/discord)
+* 🐛 **Found a bug?** [Open an issue](https://github.com/diamonddigitaldev/Dropgate/issues)
+* 💡 **Have a suggestion?** [Submit a feature request](https://github.com/diamonddigitaldev/Dropgate/issues/new?labels=enhancement)
 
 <div align="center">
   <a href="https://diamonddigital.dev/">

--- a/server/README.md
+++ b/server/README.md
@@ -33,7 +33,7 @@ To prevent and monitor for abuse, `DEBUG`-level logging and strict rate limits a
 
 ## 🌍 Overview
 
-**Dropgate Server** is the official backend and reference implementation for secure, privacy-focused file sharing using Dropgate (DGUP and DGDTP) protocols.
+**Dropgate Server** is the official backend and reference implementation for secure, privacy-focused file sharing using the Dropgate protocols: [DGUP (Dropgate Upload Protocol)](../docs/technical/DGUP.md) and [DGDTP (Dropgate Direct Transfer Protocol)](../docs/technical/DGDTP.md).
 
 It can be self-hosted easily on:
 - Home servers / NAS boxes
@@ -192,7 +192,7 @@ Run the server behind a reverse proxy that terminates TLS:
 
 ## 🗄️ Storage and Lifecycle
 
-- Uploaded files live in `server/uploads`.
+- Uploaded files live in `uploads/`.
 - Files can be set to expire after a certain period or after a certain number of downloads.
 - Incomplete uploads are cleaned up on an interval.
 
@@ -225,7 +225,7 @@ See the [LICENSE](./LICENSE) file for details.
 This project uses AI tools to aid development.
 
 AI is used to:
-- Plan sigificant changes
+- Plan significant changes
 - Implement initial passes of new features
 - Perform security audits (alongside human review)
 - Fix bugs and patch security vulnerabilities


### PR DESCRIPTION
- Fix "sigificant" typo in the AI Disclosure section across all four READMEs.
- Repair the malformed ASCII project tree in the root README (correct branch
  glyphs for the only child of `packages/` and the last root-level entry).
- Replace backslash-escaped ampersands in the client README's Discord and
  Buy Me a Coffee badge URLs with plain ampersands, matching the other READMEs.
- Link DGUP and DGDTP to their protocol docs in the server README, and
  reference `uploads/` (server-relative) instead of `server/uploads`.
- Mention DGUP and DGDTP in the core README's Overview, with links to the
  protocol docs.
- Add emojis to the core README's section headings, matching the emojis used
  for equivalent headings in the sibling READMEs (Overview, Installation,
  Quick Start, License, Acknowledgements, Contact Us) and choosing reasonable
  ones for the core-only sections.